### PR TITLE
Avoid shell when executing jq

### DIFF
--- a/lib/yq.rb
+++ b/lib/yq.rb
@@ -23,12 +23,12 @@ module Yq
   end
 
   def self.search(query, json)
-    cmd = which('jq') + %Q[ '#{query}']
+    cmd = [which('jq'), query]
     input = json
     output = ""
     LOGGER.debug "sending jq #{cmd}"
 
-    Open3.popen2(cmd) do |i, o, t|
+    Open3.popen2(*cmd) do |i, o, t|
       begin
         pid = t.pid
 

--- a/spec/yq_spec.rb
+++ b/spec/yq_spec.rb
@@ -82,7 +82,7 @@ EOF
 
     it 'passes it through to jq' do
       allow(Yq).to receive(:which).with('jq').and_return('/bin/jq')
-      expect(Open3).to receive(:popen2).with("/bin/jq '#{jq_query}'").and_return(jq_response)
+      expect(Open3).to receive(:popen2).with('/bin/jq' , jq_query).and_return(jq_response)
       subject
     end
 

--- a/spec/yq_spec.rb
+++ b/spec/yq_spec.rb
@@ -11,6 +11,13 @@ foo:
     "'": value
 EOF
 
+  # support equivalent YAML syntaxes (depends on ruby version)
+  let(:yaml_regexp) {<<EOF}
+foo:
+  bar:
+    ("'"|''''|! ''''): value
+EOF
+
   let(:json) {<<EOF.chomp}
 {"foo":{"bar":{"'":"value"}}}
 EOF
@@ -102,7 +109,7 @@ EOF
 
   describe '.hash_to_yaml' do
     subject { described_class.hash_to_yaml(hash) }
-    it { is_expected.to match(yaml) }
+    it { is_expected.to match(yaml_regexp) }
   end
 
   describe '.yaml_to_json' do
@@ -112,7 +119,7 @@ EOF
 
   describe '.json_to_yaml' do
     subject { described_class.json_to_yaml(json) }
-    it { is_expected.to match(yaml) }
+    it { is_expected.to match(yaml_regexp) }
 
     context 'non-json response' do
       subject { described_class.json_to_yaml(jq_non_json_response) }
@@ -128,7 +135,7 @@ EOF
   describe '.search_yaml' do
     subject { described_class.search_yaml('.foo.bar', yaml) }
 
-    it { is_expected.to match(%q{"'": value}) }
+    it { is_expected.to match(/("'"|''''|! ''''): value/) }
   end
 
 


### PR DESCRIPTION
Extracted from #11, it's an unrelated change easier to review separately.

Allows shell metacharacters — specifically `'` — to appear inside the query, passed to jq unmodified:
```
$ echo "{\"'\": \"quote\"}" | jq ".[\"'\"]"
"quote"
$ echo "{\"'\": \"quote\"}" | yq ".[\"'\"]"
--- quote
...
```
Currently the latter doesn't work because jq is executed via bash and the built commandline is invalid:
```
sh: -c: line 0: unexpected EOF while looking for matching `"'
sh: -c: line 1: syntax error: unexpected end of file
```
In some other cases it would appear to work but the query would be modified...